### PR TITLE
[BE] Split assets to nfts and fungible on BE

### DIFF
--- a/backend/src/db/models/session.ts
+++ b/backend/src/db/models/session.ts
@@ -1,15 +1,16 @@
 import {DataTypes, Model, Optional} from 'sequelize'
 import sequelizeConnection from '@db/config'
+import { Asset } from "@types";
 
 interface SessionAttributes {
     id: number;
     secret: string;
     createdAt: Date;
     creatorAddr: string;
-    creatorAssetsJson: object;
+    creatorAssetsJson: Asset[];
     creatorNanoErg: bigint;
     guestAddr?: string;
-    guestAssetsJson?: object;
+    guestAssetsJson?: Asset[];
     guestNanoErg?: bigint;
     txPartial?: string;
     txPartialAddedOn?: string;
@@ -26,10 +27,10 @@ export interface SessionOuput extends Required<SessionAttributes> {
 class Session extends Model<SessionAttributes, SessionInput> implements SessionAttributes {
     public id!: number
     creatorAddr!: string;
-    creatorAssetsJson!: object;
+    creatorAssetsJson!: Asset[];
     creatorNanoErg!: bigint;
     guestAddr: string;
-    guestAssetsJson: object;
+    guestAssetsJson: Asset[];
     guestNanoErg: bigint;
     secret!: string;
     submittedAt: Date;

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -23,3 +23,15 @@ export const SessionEnterBodySchema: Schema = {
         guestAddr: 'string',
     },
 };
+
+export interface Nft {
+    name: string;
+    tokenId: string;
+}
+
+export interface FungibleToken {
+    name: string;
+    tokenId: string;
+    amount: number;
+    decimals: number;
+}

--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -1,5 +1,5 @@
 import {config} from "@config";
-import {Asset, Schema} from "@types";
+import {Asset, Schema, Nft, FungibleToken} from "@types";
 
 export async function explorerRequest(endpoint: string): Promise<any> {
     const res = await fetch(`${config.blockchainApiUrl}${endpoint}`);
@@ -27,4 +27,31 @@ export const validateObject = async (obj: any, model: Schema) => {
         }
     }
     return true;
+}
+
+// TODO make differentiating between NFTs and fungible tokens according to standard
+export const splitAssets = (assets: Asset[] | undefined | null): {nfts: Nft[], fungibleTokens: FungibleToken[]} | undefined => {
+    if(!assets) {
+        return {
+            nfts: undefined,
+            fungibleTokens: undefined,
+        };
+    }
+    const rawNfts = assets.filter((asset: Asset) => {return asset.amount === 1;});
+    const rawFungibleTokens = assets.filter((asset: Asset) => {return asset.amount !==1;});
+    const nfts = rawNfts.map((asset: Asset) => {
+        return {
+            name: asset.name,
+            tokenId: asset.tokenId,
+        };
+    });
+    const fungibleTokens = rawFungibleTokens.map((asset: Asset) => {
+        return {
+            name: asset.name,
+            tokenId: asset.tokenId,
+            amount: asset.amount,
+            decimals: asset.decimals,
+        }
+    });
+    return { nfts, fungibleTokens };
 }


### PR DESCRIPTION
* The /session/info endpoint parses assets from DB and returns nfts and fungibleTokens separately.

* The differentiation is only based on amount, needs to be done in a clean way according to the standard.