### PR TITLE
[FE] Unify success messages for guest and host

### DIFF
--- a/web/components/Profile/SwapHistory.tsx
+++ b/web/components/Profile/SwapHistory.tsx
@@ -58,8 +58,10 @@ const SwapHistoryTableEntry = (props: {
 
       <CenteredDivHorizontal style={{ width: '30%' }}>
         <CenteredDivHorizontal style={{ width: '100%' }}>
-          {swapTimestampDt.toLocaleDateString()}{' '}
-          {swapTimestampDt.toLocaleTimeString()}
+          <Text>
+            {swapTimestampDt.toLocaleDateString()}{' '}
+            {swapTimestampDt.toLocaleTimeString()}
+          </Text>
         </CenteredDivHorizontal>
       </CenteredDivHorizontal>
     </FlexDiv>

--- a/web/components/Swap/SwappingPhaseHost.tsx
+++ b/web/components/Swap/SwappingPhaseHost.tsx
@@ -2,12 +2,13 @@ import { CenteredDiv, Div, FlexDiv } from '@components/Common/Alignment';
 import { TokenSelection } from '@components/Swap/TokenSelection';
 import { Spacer } from '@components/Common/Spacer';
 import { spacing } from '@themes/spacing';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { type Wallet } from '@ergo/wallet';
 import { type ParticipantInfo } from '@components/Swap/types';
 import { SwapButton } from '@components/Swap/SwapButton';
 import { TradingSessionFinished } from '@components/Swap/TradingSessionFinished';
 import { Alert } from '@components/Common/Alert';
+import { fetchFinishedTxId } from '@components/Swap/utils';
 
 export function SwappingPhaseHost(props: {
   wallet: Wallet;
@@ -31,6 +32,14 @@ export function SwappingPhaseHost(props: {
   const [selectedNanoErgB, setSelectedNanoErgB] = useState(BigInt(0));
   const [awaitingGuestSignature, setAwaitingGuestSignature] = useState(false);
   const [txId, setTxId] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    const fetchIsFinished = async (): Promise<void> => {
+      const maybeTxId = await fetchFinishedTxId(props.tradingSessionId);
+      setTxId(maybeTxId);
+    };
+    fetchIsFinished().catch(console.error);
+  });
 
   if (txId !== undefined) {
     return <TradingSessionFinished txId={txId} />;

--- a/web/components/Swap/TradingSessionFinished.tsx
+++ b/web/components/Swap/TradingSessionFinished.tsx
@@ -1,7 +1,7 @@
 import {
+  CenteredDiv,
   CenteredDivHorizontal,
   Div,
-  FlexDiv,
 } from '@components/Common/Alignment';
 import { config } from '@config';
 import { Heading1, TextCenterAlign, A } from '@components/Common/Text';
@@ -12,20 +12,20 @@ export const TradingSessionFinished = (props: {
   txId: string;
 }): JSX.Element => {
   return (
-    <FlexDiv>
+    <CenteredDiv>
       <Div>
         <CenteredDivHorizontal>
           <Heading1>Success!</Heading1>
         </CenteredDivHorizontal>
         <CenteredDivHorizontal>
           <TextCenterAlign>
-            The{' '}
+            The&nbsp;
             <A
               href={`${config.explorerFrontendUrl}/en/transactions/${props.txId}`}
             >
               transaction
-            </A>{' '}
-            was submitted successfully.
+            </A>
+            &nbsp; was submitted successfully.
           </TextCenterAlign>
         </CenteredDivHorizontal>
         <CenteredDivHorizontal>
@@ -36,10 +36,9 @@ export const TradingSessionFinished = (props: {
       <CenteredDivHorizontal>
         <TextCenterAlign>
           If the transaction is not confirmed within 1 hour, please open a new
-          trading session and try again. No funds can be lost by opening new
-          identiacal trading sessions.
+          trading session and try again.
         </TextCenterAlign>
       </CenteredDivHorizontal>
-    </FlexDiv>
+    </CenteredDiv>
   );
 };

--- a/web/components/Swap/utils.ts
+++ b/web/components/Swap/utils.ts
@@ -1,4 +1,5 @@
 import { type SignedInput } from '@fleet-sdk/common';
+import { backendRequest } from '@utils/utils';
 
 export const combineSignedInputs = (
   signedInputsA: SignedInput[],
@@ -14,4 +15,22 @@ export const combineSignedInputs = (
     combinedInputs[inputIndex] = signedInputsB[i];
   });
   return combinedInputs;
+};
+
+export const fetchFinishedTxId = async (
+  tradingSessionId: string
+): Promise<string | undefined> => {
+  const isFinishedResponse = await backendRequest(
+    `/tx?secret=${tradingSessionId}`
+  );
+  if (
+    isFinishedResponse.status !== 200 ||
+    isFinishedResponse?.body?.submitted === undefined
+  ) {
+    console.error('Failed to get isFinished');
+    return undefined;
+  } else if (isFinishedResponse.body.submitted === true) {
+    return isFinishedResponse.body.txId;
+  }
+  return undefined;
 };


### PR DESCRIPTION
* Only use single component for both.

* Always display success message after the session tx was submitted. Until now, a token selection was shown again on host's reload.

* Center success messages.